### PR TITLE
Refactor interfaces, styles, card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Home from './components/home/Home';
 import BonsaiUpload from './components/bonsaiUpload/BonsaiUpload';
 import AuthForm from './components/authForm/AuthForm';
 import NavBar from './components/navBar/NavBar';
+import BonsaiPage from './components/bonsaiPage/BonsaiPage';
 
 const router = createBrowserRouter([{ path: '*', element: <Root /> }]);
 
@@ -29,6 +30,7 @@ function Root() {
         <Route path="/" element={<Home />} />
         <Route path="/upload" element={<BonsaiUpload />} />
         <Route path="/login" element={<AuthForm />} />
+        <Route path="/bonsai/:id" element={<BonsaiPage />} />
       </Routes>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import BonsaiUpload from './components/bonsaiUpload/BonsaiUpload';
 import AuthForm from './components/authForm/AuthForm';
 import NavBar from './components/navBar/NavBar';
 import BonsaiPage from './components/bonsaiPage/BonsaiPage';
+import ErrorBoundary from './components/errorBoundary/ErrorBoundary'; // Import the ErrorBoundary
 
 const router = createBrowserRouter([{ path: '*', element: <Root /> }]);
 
@@ -26,12 +27,14 @@ function Root() {
   return (
     <>
       <NavBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/upload" element={<BonsaiUpload />} />
-        <Route path="/login" element={<AuthForm />} />
-        <Route path="/bonsai/:id" element={<BonsaiPage />} />
-      </Routes>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/upload" element={<BonsaiUpload />} />
+          <Route path="/login" element={<AuthForm />} />
+          <Route path="/bonsai/:id" element={<BonsaiPage />} />
+        </Routes>
+      </ErrorBoundary>
     </>
   );
 }

--- a/src/BonsaiCategoryConstants.tsx
+++ b/src/BonsaiCategoryConstants.tsx
@@ -1,0 +1,8 @@
+export const HARDINESSZONES = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
+'4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
+'10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
+
+export const BONSAISTYLES = ['Broom style (Hokidachi)', 'Cascade (Kengai)', 'Double trunk (Sokan)',
+'Formal upright (Chokkan)', 'Forest (Yose-ue)', 'Growing in a rock (Ishisuki)', 'Growing on a rock (Seki-Joju)',
+'Informal upright (Moyogi)', 'Literati (Bunjin-gi)', 'Multi-trunk (Ikadabuki)', 'Other', 'Raft (Ikadabuki)',
+'Semi-cascade (Han-kengai)', 'Shari (Sharimiki)', 'Slanting (Shakan)', 'Windswept (Fukinagashi)'];

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -32,16 +32,4 @@ const bonsaiData = {
   species: 'Western Hemlock'
 };
 
-const bonsaiCardData = {
-  id: '1',
-  photoUrl: bonsaiChapterData1.photoUrls[0],
-  species: bonsaiData.species,
-  user: bonsaiData.user,
-  location:
-    bonsaiData.geoLocation !== ''
-      ? bonsaiData.geoLocation
-      : bonsaiData.hardinessZone,
-  style: bonsaiData.style
-};
-
-export { bonsaiData, bonsaiChapterData1, bonsaiChapterData2, bonsaiCardData };
+export { bonsaiData, bonsaiChapterData1, bonsaiChapterData2 };

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -11,7 +11,7 @@ const bonsaiChapterData = {
 const bonsaiData = {
   id: '1',
   user: 'Pablo',
-  bonsaiChapters: [bonsaiChapterData],
+  bonsaiChapters: [bonsaiChapterData, bonsaiChapterData, bonsaiChapterData],
   geoLocation: 'San Francisco, CA',
   hardinessZone: '9A',
   height: '6in',

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -19,9 +19,17 @@ const bonsaiChapterData2 = {
   caption: 'Woah it became a sunflower'
 };
 
+const userData = {
+  avatar:
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg',
+  username: 'JNakster',
+  fullname: 'John Naka'
+};
+
+
 const bonsaiData = {
   id: '1',
-  user: 'Pablo',
+  user: userData,
   bonsaiChapters: [bonsaiChapterData1, bonsaiChapterData2],
   geoLocation: 'San Francisco, CA',
   hardinessZone: '9A',
@@ -32,4 +40,6 @@ const bonsaiData = {
   species: 'Western Hemlock'
 };
 
-export { bonsaiData, bonsaiChapterData1, bonsaiChapterData2 };
+
+
+export { bonsaiData, bonsaiChapterData1, bonsaiChapterData2, userData };

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -1,7 +1,17 @@
+const bonsaiChapterData = {
+  photoUrls: [
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
+  ],
+  bonsaiId: '1',
+  date: new Date(),
+  caption:
+    "1 year mark. Bonsai collected from Burton, WA forest, where it was growing from a fallen tree, it's base lying perpendicular to the ground"
+};
+
 const bonsaiData = {
   id: '1',
   user: 'Pablo',
-  bonsaiChapter: '',
+  bonsaiChapters: [bonsaiChapterData],
   geoLocation: 'San Francisco, CA',
   hardinessZone: '9A',
   height: '6in',
@@ -9,16 +19,6 @@ const bonsaiData = {
   nebari: '2in',
   style: 'Literati',
   species: 'Western Hemlock'
-};
-
-const bonsaiChapterData = {
-  photoUrls: [
-    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
-  ],
-  bonsai: bonsaiData,
-  date: Date.now(),
-  caption:
-    "1 year mark. Bonsai collected from Burton, WA forest, where it was growing from a fallen tree, it's base lying perpendicular to the ground"
 };
 
 const bonsaiCardData = {

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -1,6 +1,7 @@
 const bonsaiChapterData1 = {
   photoUrls: [
-    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg',
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1712589554/wildRoots/sunflower_atfd07.png'
   ],
   bonsaiId: '1',
   date: new Date(),
@@ -10,7 +11,8 @@ const bonsaiChapterData1 = {
 
 const bonsaiChapterData2 = {
   photoUrls: [
-    'https://res.cloudinary.com/dscsiijis/image/upload/v1712589554/wildRoots/sunflower_atfd07.png'
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1712589554/wildRoots/sunflower_atfd07.png',
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
   ],
   bonsaiId: '1',
   date: new Date(),

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -1,4 +1,4 @@
-const bonsaiChapterData = {
+const bonsaiChapterData1 = {
   photoUrls: [
     'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
   ],
@@ -8,10 +8,19 @@ const bonsaiChapterData = {
     "1 year mark. Bonsai collected from Burton, WA forest, where it was growing from a fallen tree, it's base lying perpendicular to the ground"
 };
 
+const bonsaiChapterData2 = {
+  photoUrls: [
+    'https://res.cloudinary.com/dscsiijis/image/upload/v1712589554/wildRoots/sunflower_atfd07.png'
+  ],
+  bonsaiId: '1',
+  date: new Date(),
+  caption: 'Woah it became a sunflower'
+};
+
 const bonsaiData = {
   id: '1',
   user: 'Pablo',
-  bonsaiChapters: [bonsaiChapterData, bonsaiChapterData, bonsaiChapterData],
+  bonsaiChapters: [bonsaiChapterData1, bonsaiChapterData2],
   geoLocation: 'San Francisco, CA',
   hardinessZone: '9A',
   height: '6in',
@@ -23,7 +32,7 @@ const bonsaiData = {
 
 const bonsaiCardData = {
   id: '1',
-  photoUrl: bonsaiChapterData.photoUrls[0],
+  photoUrl: bonsaiChapterData1.photoUrls[0],
   species: bonsaiData.species,
   user: bonsaiData.user,
   location:
@@ -33,4 +42,4 @@ const bonsaiCardData = {
   style: bonsaiData.style
 };
 
-export { bonsaiData, bonsaiChapterData, bonsaiCardData };
+export { bonsaiData, bonsaiChapterData1, bonsaiChapterData2, bonsaiCardData };

--- a/src/bonsaiProfDummyData.ts
+++ b/src/bonsaiProfDummyData.ts
@@ -1,4 +1,5 @@
 const bonsaiData = {
+  id: '1',
   user: 'Pablo',
   bonsaiChapter: '',
   geoLocation: 'San Francisco, CA',
@@ -21,6 +22,7 @@ const bonsaiChapterData = {
 };
 
 const bonsaiCardData = {
+  id: '1',
   photoUrl: bonsaiChapterData.photoUrls[0],
   species: bonsaiData.species,
   user: bonsaiData.user,

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -9,7 +9,7 @@
 
 .cardContainer:hover {
   cursor: pointer;
-  background-color: rgba(128, 128, 128, 0.1);
+  background-color: var(--subtle-background);
 }
 
 .bonsaiInfoContainer {
@@ -43,7 +43,7 @@
   max-width: 900px;
   width: 100%;
   border-radius: 10px;
-  background-color: rgba(128, 128, 128, 0.3);
+  background-color: var(--subtle-background);
 }
 
 .image {

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -3,6 +3,13 @@
   flex-direction: column;
   max-height: 800px;
   height: fit-content;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.cardContainer:hover {
+  cursor: pointer;
+  background-color: rgba(128, 128, 128, 0.1);
 }
 
 hr {

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -9,7 +9,7 @@
 
 .cardContainer:hover {
   cursor: pointer;
-  background-color: var(--subtle-background);
+  background-color: var(--primary-color-site);
 }
 
 .bonsaiInfoContainer {
@@ -38,10 +38,14 @@
 .imageFrame {
   display: flex;
   justify-content: center;
+  align-items: center;
   height: 480px;
   width: 900px;
-  border-radius: 10px;
   background-color: var(--subtle-background);
+  padding: 10px 0;
+  border-radius: 10px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .image {
@@ -50,4 +54,55 @@
   width: auto;
   height: auto;
   object-fit: contain;
+}
+
+.image:hover {
+  cursor: default;
+}
+
+.chapterButton {
+  font-size: 20px;
+  margin: 8px;
+  border-radius: 5px;
+  background-color: transparent;
+  border: none;
+  padding: 10px 20px;
+  width: min-content;
+  height: min-content;
+}
+
+.chapterButton:hover {
+  cursor: pointer;
+  background-color: var(--primary-color-site);
+}
+
+.chapterInfo {
+  display: flex;
+  align-items: center;
+  height: min-content;
+  width: 900px;
+  background-color: var(--subtle-background);
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  padding-bottom: 5px;
+}
+
+.chapterDate {
+  width: 100px;
+  padding-left: 10px;
+  font-size: small;
+}
+
+.chapterCaption,
+.chapterDate {
+  font-style: italic;
+  margin: 4px 0;
+  color: grey;
+}
+
+.captionContainer {
+  width: calc(100% - 200px);
+  display: flex;
+  justify-content: center;
+  margin-right: 100px;
 }

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -12,10 +12,6 @@
   background-color: rgba(128, 128, 128, 0.1);
 }
 
-hr {
-  width: 100%;
-}
-
 .bonsaiInfoContainer {
   display: flex;
   align-items: center;

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -38,10 +38,8 @@
 .imageFrame {
   display: flex;
   justify-content: center;
-  max-height: 480px;
-  height: fit-content;
-  max-width: 900px;
-  width: 100%;
+  height: 480px;
+  width: 900px;
   border-radius: 10px;
   background-color: var(--subtle-background);
 }

--- a/src/components/bonsaiCard/BonsaiCard.module.css
+++ b/src/components/bonsaiCard/BonsaiCard.module.css
@@ -9,7 +9,7 @@
 
 .cardContainer:hover {
   cursor: pointer;
-  background-color: var(--primary-color-site);
+  background-color: whitesmoke;
 }
 
 .bonsaiInfoContainer {

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -2,48 +2,40 @@ import { bonsaiCardData } from '../../bonsaiProfDummyData';
 import { useNavigate } from 'react-router-dom';
 import UserIcon from '../userIcon/UserIcon';
 import styles from './BonsaiCard.module.css';
+import { Bonsai } from '../../interfaces';
 
 // TODO:
 // Refactor to display leading photo
 // from each chapter in a gallery
 
-interface BonsaiCardData {
-  id: string;
-  photoUrl: string;
-  species: string;
-  user: string;
-  location: string;
-  style: string;
-}
-
-function BonsaiCard({ cardData }: { cardData: BonsaiCardData }) {
+function BonsaiCard({ bonsai }: { bonsai: Bonsai }) {
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    navigate(`/bonsai/${cardData.id}`);
+    navigate(`/bonsai/${bonsai.id}`);
   };
 
   return (
     <div className={styles.cardContainer} onClick={handleCardClick}>
       <div className={styles.bonsaiInfoContainer}>
-        <UserIcon user={{ username: bonsaiCardData.user }} />
+        <UserIcon user={{ username: bonsai.user }} />
         <div className={styles.bonsaiInfoCell}>
           <p>Species: </p>
-          <p>{bonsaiCardData.species}</p>
+          <p>{bonsai.species}</p>
         </div>
 
         <div className={styles.bonsaiInfoCell}>
           <p>Style: </p>
-          <p>{bonsaiCardData.style}</p>
+          <p>{bonsai.style}</p>
         </div>
 
         <div className={styles.bonsaiInfoCell}>
           <p>Location: </p>
-          <p>{bonsaiCardData.location}</p>
+          <p>{bonsai.geoLocation}</p>
         </div>
       </div>
       <div className={styles.imageFrame}>
-        <img className={styles.image} src={bonsaiCardData.photoUrl} alt="" />
+        <img className={styles.image} src={} alt="" />
       </div>
     </div>
   );

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -3,6 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import UserIcon from '../userIcon/UserIcon';
 import styles from './BonsaiCard.module.css';
 
+// TODO:
+// Refactor to display leading photo
+// from each chapter in a gallery
+
 interface BonsaiCardData {
   id: string;
   photoUrl: string;

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -33,7 +33,6 @@ function BonsaiCard({ cardData }: { cardData: BonsaiCardData }) {
       <div className={styles.imageFrame}>
         <img className={styles.image} src={cardData.photoUrl} alt="" />
       </div>
-      <hr />
     </div>
   );
 }

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -1,8 +1,10 @@
 import { bonsaiCardData } from '../../bonsaiProfDummyData';
+import { useNavigate } from 'react-router-dom';
 import UserIcon from '../userIcon/UserIcon';
 import styles from './BonsaiCard.module.css';
 
 interface BonsaiCardData {
+  id: string;
   photoUrl: string;
   species: string;
   user: string;
@@ -11,8 +13,14 @@ interface BonsaiCardData {
 }
 
 function BonsaiCard({ cardData }: { cardData: BonsaiCardData }) {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(`/bonsai/${cardData.id}`);
+  };
+
   return (
-    <div className={styles.cardContainer}>
+    <div className={styles.cardContainer} onClick={handleCardClick}>
       <div className={styles.bonsaiInfoContainer}>
         <UserIcon user={{ username: bonsaiCardData.user }} />
         <div className={styles.bonsaiInfoCell}>
@@ -31,7 +39,7 @@ function BonsaiCard({ cardData }: { cardData: BonsaiCardData }) {
         </div>
       </div>
       <div className={styles.imageFrame}>
-        <img className={styles.image} src={cardData.photoUrl} alt="" />
+        <img className={styles.image} src={bonsaiCardData.photoUrl} alt="" />
       </div>
     </div>
   );

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -44,7 +44,7 @@ function BonsaiCard({ bonsai }: { bonsai: Bonsai }) {
   return (
     <div className={styles.cardContainer} onClick={handleCardClick}>
       <div className={styles.bonsaiInfoContainer}>
-        <UserIcon user={{ username: bonsai.user }} />
+        <UserIcon user={bonsai.user} />
         <div className={styles.bonsaiInfoCell}>
           <p>Species: </p>
           <p>{bonsai.species}</p>

--- a/src/components/bonsaiCard/BonsaiCard.tsx
+++ b/src/components/bonsaiCard/BonsaiCard.tsx
@@ -1,19 +1,45 @@
-import { bonsaiCardData } from '../../bonsaiProfDummyData';
 import { useNavigate } from 'react-router-dom';
 import UserIcon from '../userIcon/UserIcon';
 import styles from './BonsaiCard.module.css';
 import { Bonsai } from '../../interfaces';
-
-// TODO:
-// Refactor to display leading photo
-// from each chapter in a gallery
+import { useState, useEffect } from 'react';
 
 function BonsaiCard({ bonsai }: { bonsai: Bonsai }) {
   const navigate = useNavigate();
+  const [currentChapterIndex, setCurrentChapterIndex] = useState(0);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleNextChapter = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentChapterIndex(
+        (prevIndex) => (prevIndex + 1) % bonsai.bonsaiChapters.length
+      );
+    }
+  };
+
+  const handlePrevChapter = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentChapterIndex(
+        (prevIndex) =>
+          (prevIndex - 1 + bonsai.bonsaiChapters.length) %
+          bonsai.bonsaiChapters.length
+      );
+    }
+  };
 
   const handleCardClick = () => {
     navigate(`/bonsai/${bonsai.id}`);
   };
+
+  useEffect(() => {
+    if (bonsai) {
+      setIsProcessing(false);
+    }
+  }, [currentChapterIndex, bonsai]);
 
   return (
     <div className={styles.cardContainer} onClick={handleCardClick}>
@@ -35,7 +61,37 @@ function BonsaiCard({ bonsai }: { bonsai: Bonsai }) {
         </div>
       </div>
       <div className={styles.imageFrame}>
-        <img className={styles.image} src={} alt="" />
+        <button
+          className={styles.chapterButton}
+          onClick={handlePrevChapter}
+          disabled={isProcessing || bonsai.bonsaiChapters.length === 0}
+        >
+          {'<'}
+        </button>
+        <img
+          onClick={(e) => e.stopPropagation()}
+          className={styles.image}
+          src={bonsai.bonsaiChapters[currentChapterIndex].photoUrls[0]}
+          alt=""
+        />
+        <button
+          className={styles.chapterButton}
+          onClick={handleNextChapter}
+          disabled={isProcessing || bonsai.bonsaiChapters.length === 0}
+        >
+          {'>'}
+        </button>
+      </div>
+
+      <div className={styles.chapterInfo}>
+        <p className={styles.chapterDate}>
+          {bonsai.bonsaiChapters[currentChapterIndex].date.toDateString()}
+        </p>
+        <div className={styles.captionContainer}>
+          <p className={styles.chapterCaption}>
+            {bonsai.bonsaiChapters[currentChapterIndex].caption}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
+++ b/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
@@ -3,22 +3,20 @@ import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import styles from './BonsaiChapterForm.module.css';
 
-interface BonsaiChapter {
+interface BonsaiChapterFile {
   photos: (File | null)[];
   caption: string;
   date: Date;
 }
 
-interface BonsaiChapterFormProps {
-  onSubmit: (chapter: BonsaiChapter) => void;
-  chapter?: BonsaiChapter;
-}
-
-const BonsaiChapterForm: React.FC<BonsaiChapterFormProps> = ({
+function BonsaiChapterForm({
   onSubmit,
   chapter
-}) => {
-  const [bonsaiChapter, setBonsaiChapter] = useState<BonsaiChapter>(
+}: {
+  onSubmit: (chapter: BonsaiChapterFile) => void;
+  chapter?: BonsaiChapterFile;
+}) {
+  const [bonsaiChapter, setBonsaiChapter] = useState<BonsaiChapterFile>(
     chapter || { photos: [], caption: '', date: new Date() }
   );
 
@@ -166,6 +164,6 @@ const BonsaiChapterForm: React.FC<BonsaiChapterFormProps> = ({
       </form>
     </DndProvider>
   );
-};
+}
 
 export default BonsaiChapterForm;

--- a/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
+++ b/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import styles from './BonsaiChapterForm.module.css';

--- a/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
+++ b/src/components/bonsaiChapterForm/BonsaiChapterForm.tsx
@@ -2,12 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import styles from './BonsaiChapterForm.module.css';
-
-interface BonsaiChapterFile {
-  photos: (File | null)[];
-  caption: string;
-  date: Date;
-}
+import { BonsaiChapterFile } from '../../interfaces';
 
 function BonsaiChapterForm({
   onSubmit,

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -45,11 +45,12 @@ function BonsaiDataForm({
     <form onSubmit={handleSubmit}>
       <h2>Add Bonsai Data</h2>
       <div>
-        <label className={styles.hardinessLabel}>Hardiness Zone:</label>
+        <label className={styles.hardinessLabel} htmlFor='hardiness'>Hardiness Zone:</label>
         <select
           value={hardinessZone}
           onChange={(e) => setHardinessZone(e.target.value)}
           required
+          id='hardiness'
         >
           <option value="" disabled>
             Select Hardiness Zone
@@ -92,10 +93,13 @@ function BonsaiDataForm({
           }
         />
       </div>
+      <div>
+      <label htmlFor="style">Bonsai Style: </label>
       <select
           value={style}
           onChange={(e) => setStyle(e.target.value)}
           required
+          id='style'
         >
           <option value="" disabled>
             Select Style
@@ -106,6 +110,8 @@ function BonsaiDataForm({
             </option>
           ))}
         </select>
+      </div>
+
       <div>
         <label>Species:</label>
         <input

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -20,6 +20,10 @@ function BonsaiDataForm({
   const [style, setStyle] = useState(bonsaiData?.style || '');
   const [species, setSpecies] = useState(bonsaiData?.species || '');
 
+  const HARDINESSZONES = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
+    '4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
+     '10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const bonsaiData: Bonsai = {
@@ -38,9 +42,7 @@ function BonsaiDataForm({
   };
 
 
-  const hardinessZones = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
-    '4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
-     '10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
+
 
   return (
     <form onSubmit={handleSubmit}>
@@ -55,7 +57,7 @@ function BonsaiDataForm({
           <option value="" disabled>
             Select Hardiness Zone
           </option>
-          {hardinessZones.map((zone) => (
+          {HARDINESSZONES.map((zone) => (
             <option key={zone} value={zone}>
               {zone}
             </option>

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState} from 'react';
 import styles from './BonsaiDataForm.module.css';
 import { Bonsai, User } from '../../interfaces';
 
@@ -37,10 +37,10 @@ function BonsaiDataForm({
     onSubmit(bonsaiData);
   };
 
-  const hardinessZones = [];
-  for (let i = 0; i <= 13; i++) {
-    hardinessZones.push(`${i}a`, `${i}b`);
-  }
+
+  const hardinessZones = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
+    '4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
+     '10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
 
   return (
     <form onSubmit={handleSubmit}>

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,37 +1,31 @@
 import React, { useState } from 'react';
 import styles from './BonsaiDataForm.module.css';
+import { Bonsai } from '../../interfaces';
 
-interface BonsaiData {
-  hardiness_zone: string;
-  height: number | '';
-  width: number | '';
-  nebari: number | '';
-  style: string;
-  species: string;
-}
-
-interface BonsaiDataFormProps {
-  onSubmit: (data: BonsaiData) => void;
-  bonsaiData?: BonsaiData;
-}
-
-const BonsaiDataForm: React.FC<BonsaiDataFormProps> = ({
+function BonsaiDataForm({
   onSubmit,
   bonsaiData
-}) => {
+}: {
+  onSubmit: (data: Bonsai) => void;
+  bonsaiData: Bonsai;
+}) {
   const [hardinessZone, setHardinessZone] = useState(
-    bonsaiData?.hardiness_zone || ''
+    bonsaiData?.hardinessZone || ''
   );
-  const [height, setHeight] = useState<number | ''>(bonsaiData?.height || '');
-  const [width, setWidth] = useState<number | ''>(bonsaiData?.width || '');
-  const [nebari, setNebari] = useState<number | ''>(bonsaiData?.nebari || '');
+  const [height, setHeight] = useState(bonsaiData?.height || '');
+  const [width, setWidth] = useState(bonsaiData?.width || '');
+  const [nebari, setNebari] = useState(bonsaiData?.nebari || '');
   const [style, setStyle] = useState(bonsaiData?.style || '');
   const [species, setSpecies] = useState(bonsaiData?.species || '');
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    const bonsaiData: BonsaiData = {
-      hardiness_zone: hardinessZone,
+    const bonsaiData: Bonsai = {
+      id: '',
+      user: '',
+      geoLocation: '',
+      bonsaiChapters: [],
+      hardinessZone: hardinessZone,
       height: height,
       species: species,
       width: width !== '' ? width : '',
@@ -72,7 +66,7 @@ const BonsaiDataForm: React.FC<BonsaiDataFormProps> = ({
           type="number"
           value={height}
           onChange={(e) =>
-            setHeight(e.target.value ? parseFloat(e.target.value) : '')
+            setHeight(e.target.value )
           }
           required
         />
@@ -83,7 +77,7 @@ const BonsaiDataForm: React.FC<BonsaiDataFormProps> = ({
           type="number"
           value={width}
           onChange={(e) =>
-            setWidth(e.target.value ? parseFloat(e.target.value) : '')
+            setWidth(e.target.value )
           }
         />
       </div>
@@ -93,7 +87,7 @@ const BonsaiDataForm: React.FC<BonsaiDataFormProps> = ({
           type="number"
           value={nebari}
           onChange={(e) =>
-            setNebari(e.target.value ? parseFloat(e.target.value) : '')
+            setNebari(e.target.value )
           }
         />
       </div>
@@ -119,6 +113,6 @@ const BonsaiDataForm: React.FC<BonsaiDataFormProps> = ({
       </button>
     </form>
   );
-};
+}
 
 export default BonsaiDataForm;

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState} from 'react';
 import styles from './BonsaiDataForm.module.css';
 import { Bonsai, User } from '../../interfaces';
+import { HARDINESSZONES, BONSAISTYLES } from '../../BonsaiCategoryConstants';
 
 function BonsaiDataForm({
   onSubmit,
@@ -19,10 +20,6 @@ function BonsaiDataForm({
   const [nebari, setNebari] = useState(bonsaiData?.nebari || '');
   const [style, setStyle] = useState(bonsaiData?.style || '');
   const [species, setSpecies] = useState(bonsaiData?.species || '');
-
-  const HARDINESSZONES = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
-    '4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
-     '10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -95,14 +92,20 @@ function BonsaiDataForm({
           }
         />
       </div>
-      <div>
-        <label>Style:</label>
-        <input
-          type="text"
+      <select
           value={style}
           onChange={(e) => setStyle(e.target.value)}
-        />
-      </div>
+          required
+        >
+          <option value="" disabled>
+            Select Style
+          </option>
+          {BONSAISTYLES.map((style) => (
+            <option key={style} value={style}>
+              {style}
+            </option>
+          ))}
+        </select>
       <div>
         <label>Species:</label>
         <input

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -7,7 +7,7 @@ function BonsaiDataForm({
   bonsaiData
 }: {
   onSubmit: (data: Bonsai) => void;
-  bonsaiData: Bonsai;
+  bonsaiData?: Bonsai;
 }) {
   const [hardinessZone, setHardinessZone] = useState(
     bonsaiData?.hardinessZone || ''

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import styles from './BonsaiDataForm.module.css';
-import { Bonsai } from '../../interfaces';
+import { Bonsai, User } from '../../interfaces';
 
 function BonsaiDataForm({
   onSubmit,
-  bonsaiData
+  bonsaiData,
+  userData
 }: {
   onSubmit: (data: Bonsai) => void;
   bonsaiData?: Bonsai;
+  userData: User;
 }) {
   const [hardinessZone, setHardinessZone] = useState(
     bonsaiData?.hardinessZone || ''
@@ -22,7 +24,7 @@ function BonsaiDataForm({
     event.preventDefault();
     const bonsaiData: Bonsai = {
       id: '',
-      user: '',
+      user: userData,
       geoLocation: '',
       bonsaiChapters: [],
       hardinessZone: hardinessZone,

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -33,7 +33,7 @@
   scrollbar-width: none;
   margin: 0 0 10px 0;
   border: 1px solid var(--secondary-color-site);
-  background-color: rgba(128, 128, 128, 0.2);
+  background-color: var(--subtle-background);
   border-radius: 10px;
   padding: 2px;
 }
@@ -57,8 +57,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  overflow: hidden;
-  background-color: rgba(128, 128, 128, 0.2);
+  background-color: var(--subtle-background);
   border-radius: 10px;
 }
 

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -1,0 +1,75 @@
+.chapterContainer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.bonsaiData,
+.chapterInfo,
+.imageFrame {
+  width: 60vw;
+}
+.bonsaiData > * {
+  margin: 5px;
+}
+
+.imageGallery {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.chapterInfo {
+  height: 100px;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  margin: 0 0 10px 0;
+  border: 1px solid var(--secondary-color-site);
+  background-color: rgba(128, 128, 128, 0.2);
+  border-radius: 10px;
+  padding: 2px;
+}
+
+.chapterDate,
+.chapterCaption {
+  margin: 4px;
+  padding: 0;
+}
+
+.chapterDate {
+  font-style: italic;
+  color: rgba(0, 0, 0, 0.8);
+}
+
+.imageFrame {
+  border: 1px solid var(--primary-color-site);
+  display: flex;
+  height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  background-color: rgba(128, 128, 128, 0.2);
+  border-radius: 10px;
+}
+
+.chapterContainer > button {
+  width: min-content;
+  height: min-content;
+  margin: 5px;
+}
+
+.chapterImage {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -129,3 +129,18 @@
   max-height: 100%;
   object-fit: contain;
 }
+
+.imageButton {
+  font-size: 20px;
+  margin: 8px;
+  border-radius: 5px;
+  background-color: transparent;
+  border: none;
+  width: min-content;
+  height: min-content;
+}
+
+.imageButton:hover {
+  cursor: pointer;
+  background-color: var(--primary-color-site);
+}

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -61,6 +61,26 @@
   flex-wrap: wrap;
 }
 
+.chapterNav {
+  display: flex;
+  align-items: center;
+}
+
+.chapterButton {
+  font-size: 20px;
+  margin: 8px;
+  border-radius: 5px;
+  background-color: transparent;
+  border: none;
+  width: min-content;
+  height: min-content;
+}
+
+.chapterButton:hover {
+  cursor: pointer;
+  background-color: var(--primary-color-site);
+}
+
 .imageGallery {
   display: flex;
   width: 100%;
@@ -104,26 +124,8 @@
   border-radius: 10px;
 }
 
-.chapterContainer > button {
-  width: min-content;
-  height: min-content;
-  margin: 5px;
-}
-
 .chapterImage {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-}
-
-.galleryButton {
-  font-size: 20px;
-  margin: 4px;
-  border-radius: 5px;
-  padding: 4px 8px;
-  border: 1px solid black;
-}
-
-.galleryButton:hover {
-  cursor: pointer;
 }

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -116,6 +116,14 @@
   object-fit: contain;
 }
 
+.galleryButton {
+  font-size: 20px;
+  margin: 4px;
+  border-radius: 5px;
+  padding: 4px 8px;
+  border: 1px solid black;
+}
+
 .galleryButton:hover {
   cursor: pointer;
 }

--- a/src/components/bonsaiPage/BonsaiPage.module.css
+++ b/src/components/bonsaiPage/BonsaiPage.module.css
@@ -1,3 +1,9 @@
+.pageContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .chapterContainer {
   display: flex;
   flex-direction: column;
@@ -9,13 +15,50 @@
   margin-bottom: 20px;
 }
 
-.bonsaiData,
+.bonsaiDataContainer,
 .chapterInfo,
 .imageFrame {
   width: 60vw;
 }
-.bonsaiData > * {
+.categoryContainer {
+  display: flex;
   margin: 5px;
+  border: 1px solid var(--primary-color-site);
+  padding: 2px 6px;
+  border-radius: 10px;
+  background-color: white;
+}
+
+.categoryContainer:hover {
+  cursor: pointer;
+  background-color: var(--subtle-background);
+}
+
+.categoryData:hover,
+.categoryLabel:hover {
+  cursor: pointer;
+}
+
+.categoryLabel,
+.categoryData {
+  padding: 0;
+  margin: 0;
+}
+
+.categoryLabel {
+  margin-right: 4px;
+}
+
+.categoryData {
+  font-weight: 600;
+}
+
+.bonsaiDataContainer {
+  border: 1px solid var(--primary-color-site);
+  border-radius: 10px;
+  background-color: var(--subtle-background);
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .imageGallery {
@@ -71,4 +114,8 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+}
+
+.galleryButton:hover {
+  cursor: pointer;
 }

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -1,18 +1,46 @@
-import styles from './BonsaiPage.module.css';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { bonsaiData } from '../../bonsaiProfDummyData';
+
+interface BonsaiChapter {
+  photoUrls: string[];
+  date: Date;
+  caption: string;
+  bonsaiId: string;
+}
+
+interface Bonsai {
+  id: string;
+  user: string;
+  species: string;
+  geoLocation: string;
+  style: string;
+  height: string;
+  width: string;
+  nebari: string;
+  hardinessZone: string;
+  bonsaiChapters: BonsaiChapter[];
+}
 
 export default function BonsaiPage() {
   const { id } = useParams<{ id: string }>();
+  const [bonsai, setBonsai] = useState<Bonsai | null>(null);
 
   useEffect(() => {
     console.log('Fetching bonsai with ID: ', id);
+    setBonsai(bonsaiData);
   }, [id]);
 
   return (
     <div>
       <h1>Bonsai Page</h1>
       <p>Displaying details for bonsai with ID: {id}</p>
+      {bonsai && (
+        <div>
+          <p>Species: {bonsai.species}</p>
+          <p>User: {bonsai.user}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -72,7 +72,7 @@ export default function BonsaiPage() {
     <div>
       {bonsai && (
         <div className={styles.pageContainer}>
-          <h1>{`${bonsai.user}'s ${bonsai.species}`}</h1>
+          <h1>{`${bonsai.user.username}'s ${bonsai.species}`}</h1>
           <div className={styles.bonsaiDataContainer}>
             {bonsai.geoLocation && (
               <div className={styles.categoryContainer}>

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -27,6 +27,7 @@ export default function BonsaiPage() {
   const { id } = useParams<{ id: string }>();
   const [bonsai, setBonsai] = useState<Bonsai | null>(null);
   const [currentChapterIndex, setCurrentChapterIndex] = useState(0);
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
@@ -34,22 +35,48 @@ export default function BonsaiPage() {
     setBonsai(bonsaiData);
   }, [id]);
 
-  const handleNextPhoto = () => {
+  const handleNextChapter = () => {
     if (bonsai && !isProcessing) {
       setIsProcessing(true);
       setCurrentChapterIndex(
         (prevIndex) => (prevIndex + 1) % bonsai.bonsaiChapters.length
       );
+      setCurrentImageIndex(0); // Reset image index when chapter changes
     }
   };
 
-  const handlePrevPhoto = () => {
+  const handlePrevChapter = () => {
     if (bonsai && !isProcessing) {
       setIsProcessing(true);
       setCurrentChapterIndex(
         (prevIndex) =>
           (prevIndex - 1 + bonsai.bonsaiChapters.length) %
           bonsai.bonsaiChapters.length
+      );
+      setCurrentImageIndex(0); // Reset image index when chapter changes
+    }
+  };
+
+  const handleNextImage = () => {
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentImageIndex(
+        (prevIndex) =>
+          (prevIndex + 1) %
+          bonsai.bonsaiChapters[currentChapterIndex].photoUrls.length
+      );
+    }
+  };
+
+  const handlePrevImage = () => {
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentImageIndex(
+        (prevIndex) =>
+          (prevIndex -
+            1 +
+            bonsai.bonsaiChapters[currentChapterIndex].photoUrls.length) %
+          bonsai.bonsaiChapters[currentChapterIndex].photoUrls.length
       );
     }
   };
@@ -58,7 +85,7 @@ export default function BonsaiPage() {
     if (bonsai) {
       setIsProcessing(false);
     }
-  }, [currentChapterIndex, bonsai]);
+  }, [currentChapterIndex, currentImageIndex, bonsai]);
 
   return (
     <div>
@@ -106,7 +133,7 @@ export default function BonsaiPage() {
               <div className={styles.chapterNav}>
                 <button
                   className={styles.chapterButton}
-                  onClick={handlePrevPhoto}
+                  onClick={handlePrevChapter}
                   disabled={isProcessing}
                 >
                   {'<'}
@@ -114,7 +141,7 @@ export default function BonsaiPage() {
                 <h2> Chapter {`${currentChapterIndex + 1}`}</h2>
                 <button
                   className={styles.chapterButton}
-                  onClick={handleNextPhoto}
+                  onClick={handleNextChapter}
                   disabled={isProcessing}
                 >
                   {'>'}
@@ -133,16 +160,39 @@ export default function BonsaiPage() {
               </div>
 
               <div className={styles.imageGallery}>
+                {bonsai.bonsaiChapters[currentChapterIndex].photoUrls.length >
+                  1 && (
+                  <button
+                    className={styles.imageButton}
+                    onClick={handlePrevImage}
+                    disabled={isProcessing}
+                  >
+                    {'<'}
+                  </button>
+                )}
+
                 <div className={styles.imageFrame}>
                   <img
                     src={
-                      bonsai.bonsaiChapters[currentChapterIndex].photoUrls[0]
+                      bonsai.bonsaiChapters[currentChapterIndex].photoUrls[
+                        currentImageIndex
+                      ]
                     }
                     alt={`Bonsai Chapter ${currentChapterIndex + 1} Photo`}
                     className={styles.chapterImage}
                     onLoad={() => setIsProcessing(false)}
                   />
                 </div>
+                {bonsai.bonsaiChapters[currentChapterIndex].photoUrls.length >
+                  1 && (
+                  <button
+                    className={styles.imageButton}
+                    onClick={handleNextImage}
+                    disabled={isProcessing}
+                  >
+                    {'>'}
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -1,0 +1,20 @@
+import styles from './BonsaiPage.module.css';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+export default function BonsaiPage() {
+  const { id } = useParams<{ id: string }>();
+
+  useEffect(() => {
+    console.log('Fetching bonsai with ID: ', id);
+  }, [id]);
+
+  return (
+    <div>
+      <h1>Bonsai Page</h1>
+      <p>Displaying details for bonsai with ID: {id}</p>
+    </div>
+  );
+}
+
+BonsaiPage;

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -16,5 +16,3 @@ export default function BonsaiPage() {
     </div>
   );
 }
-
-BonsaiPage;

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -63,17 +63,43 @@ export default function BonsaiPage() {
   return (
     <div>
       {bonsai && (
-        <div>
-          <p>Displaying details for bonsai with ID: {id}</p>
-          <div className={styles.bonsaiData}>
-            <p>Species: {bonsai.species}</p>
-            <p>User: {bonsai.user}</p>
-            {bonsai.geoLocation && <p>Geo Location: {bonsai.geoLocation}</p>}
-            {bonsai.style && <p>Style: {bonsai.style}</p>}
-            {bonsai.height && <p>Height: {bonsai.height}</p>}
-            {bonsai.width && <p>Width: {bonsai.width}</p>}
-            {bonsai.nebari && <p>Nebari: {bonsai.nebari}</p>}
-            <p>Hardiness Zone: {bonsai.hardinessZone}</p>
+        <div className={styles.pageContainer}>
+          <h1>{`${bonsai.user}'s ${bonsai.species}`}</h1>
+          <div className={styles.bonsaiDataContainer}>
+            {bonsai.geoLocation && (
+              <div className={styles.categoryContainer}>
+                <label className={styles.categoryLabel}>Geo Location:</label>
+                <p className={styles.categoryData}>{bonsai.geoLocation}</p>
+              </div>
+            )}
+            {bonsai.style && (
+              <div className={styles.categoryContainer}>
+                <label className={styles.categoryLabel}>Style:</label>
+                <p className={styles.categoryData}>{bonsai.style}</p>
+              </div>
+            )}
+            {bonsai.height && (
+              <div className={styles.categoryContainer}>
+                <label className={styles.categoryLabel}>Height:</label>
+                <p className={styles.categoryData}>{bonsai.height}</p>
+              </div>
+            )}
+            {bonsai.width && (
+              <div className={styles.categoryContainer}>
+                <label className={styles.categoryLabel}>Width:</label>
+                <p className={styles.categoryData}>{bonsai.width}</p>
+              </div>
+            )}
+            {bonsai.nebari && (
+              <div className={styles.categoryContainer}>
+                <label className={styles.categoryLabel}>Nebari:</label>
+                <p className={styles.categoryData}>{bonsai.nebari}</p>
+              </div>
+            )}
+            <div className={styles.categoryContainer}>
+              <label className={styles.categoryLabel}>Hardiness Zone:</label>
+              <p className={styles.categoryData}>{bonsai.hardinessZone}</p>
+            </div>
           </div>
           {bonsai.bonsaiChapters.length > 0 && (
             <div className={styles.chapterContainer}>
@@ -90,7 +116,11 @@ export default function BonsaiPage() {
               </div>
 
               <div className={styles.imageGallery}>
-                <button onClick={handlePrevPhoto} disabled={isProcessing}>
+                <button
+                  className={styles.galleryButton}
+                  onClick={handlePrevPhoto}
+                  disabled={isProcessing}
+                >
                   {'<'}
                 </button>
                 <div className={styles.imageFrame}>
@@ -103,7 +133,11 @@ export default function BonsaiPage() {
                     onLoad={() => setIsProcessing(false)}
                   />
                 </div>
-                <button onClick={handleNextPhoto} disabled={isProcessing}>
+                <button
+                  className={styles.galleryButton}
+                  onClick={handleNextPhoto}
+                  disabled={isProcessing}
+                >
                   {'>'}
                 </button>
               </div>

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -2,26 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { bonsaiData } from '../../bonsaiProfDummyData';
 import styles from './BonsaiPage.module.css';
-
-interface BonsaiChapter {
-  photoUrls: string[];
-  date: Date;
-  caption: string;
-  bonsaiId: string;
-}
-
-interface Bonsai {
-  id: string;
-  user: string;
-  species: string;
-  geoLocation: string;
-  style: string;
-  height: string;
-  width: string;
-  nebari: string;
-  hardinessZone: string;
-  bonsaiChapters: BonsaiChapter[];
-}
+import { Bonsai } from '../../interfaces';
 
 export default function BonsaiPage() {
   const { id } = useParams<{ id: string }>();

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -103,7 +103,24 @@ export default function BonsaiPage() {
           </div>
           {bonsai.bonsaiChapters.length > 0 && (
             <div className={styles.chapterContainer}>
-              <h2> Chapter {`${currentChapterIndex + 1}`}</h2>
+              <div className={styles.chapterNav}>
+                <button
+                  className={styles.chapterButton}
+                  onClick={handlePrevPhoto}
+                  disabled={isProcessing}
+                >
+                  {'<'}
+                </button>
+                <h2> Chapter {`${currentChapterIndex + 1}`}</h2>
+                <button
+                  className={styles.chapterButton}
+                  onClick={handleNextPhoto}
+                  disabled={isProcessing}
+                >
+                  {'>'}
+                </button>
+              </div>
+
               <div className={styles.chapterInfo}>
                 <p className={styles.chapterDate}>
                   {bonsai.bonsaiChapters[
@@ -116,13 +133,6 @@ export default function BonsaiPage() {
               </div>
 
               <div className={styles.imageGallery}>
-                <button
-                  className={styles.galleryButton}
-                  onClick={handlePrevPhoto}
-                  disabled={isProcessing}
-                >
-                  {'<'}
-                </button>
                 <div className={styles.imageFrame}>
                   <img
                     src={
@@ -133,13 +143,6 @@ export default function BonsaiPage() {
                     onLoad={() => setIsProcessing(false)}
                   />
                 </div>
-                <button
-                  className={styles.galleryButton}
-                  onClick={handleNextPhoto}
-                  disabled={isProcessing}
-                >
-                  {'>'}
-                </button>
               </div>
             </div>
           )}

--- a/src/components/bonsaiPage/BonsaiPage.tsx
+++ b/src/components/bonsaiPage/BonsaiPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { bonsaiData } from '../../bonsaiProfDummyData';
+import styles from './BonsaiPage.module.css';
 
 interface BonsaiChapter {
   photoUrls: string[];
@@ -25,20 +26,89 @@ interface Bonsai {
 export default function BonsaiPage() {
   const { id } = useParams<{ id: string }>();
   const [bonsai, setBonsai] = useState<Bonsai | null>(null);
+  const [currentChapterIndex, setCurrentChapterIndex] = useState(0);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   useEffect(() => {
     console.log('Fetching bonsai with ID: ', id);
     setBonsai(bonsaiData);
   }, [id]);
 
+  const handleNextPhoto = () => {
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentChapterIndex(
+        (prevIndex) => (prevIndex + 1) % bonsai.bonsaiChapters.length
+      );
+    }
+  };
+
+  const handlePrevPhoto = () => {
+    if (bonsai && !isProcessing) {
+      setIsProcessing(true);
+      setCurrentChapterIndex(
+        (prevIndex) =>
+          (prevIndex - 1 + bonsai.bonsaiChapters.length) %
+          bonsai.bonsaiChapters.length
+      );
+    }
+  };
+
+  useEffect(() => {
+    if (bonsai) {
+      setIsProcessing(false);
+    }
+  }, [currentChapterIndex, bonsai]);
+
   return (
     <div>
-      <h1>Bonsai Page</h1>
-      <p>Displaying details for bonsai with ID: {id}</p>
       {bonsai && (
         <div>
-          <p>Species: {bonsai.species}</p>
-          <p>User: {bonsai.user}</p>
+          <p>Displaying details for bonsai with ID: {id}</p>
+          <div className={styles.bonsaiData}>
+            <p>Species: {bonsai.species}</p>
+            <p>User: {bonsai.user}</p>
+            {bonsai.geoLocation && <p>Geo Location: {bonsai.geoLocation}</p>}
+            {bonsai.style && <p>Style: {bonsai.style}</p>}
+            {bonsai.height && <p>Height: {bonsai.height}</p>}
+            {bonsai.width && <p>Width: {bonsai.width}</p>}
+            {bonsai.nebari && <p>Nebari: {bonsai.nebari}</p>}
+            <p>Hardiness Zone: {bonsai.hardinessZone}</p>
+          </div>
+          {bonsai.bonsaiChapters.length > 0 && (
+            <div className={styles.chapterContainer}>
+              <h2> Chapter {`${currentChapterIndex + 1}`}</h2>
+              <div className={styles.chapterInfo}>
+                <p className={styles.chapterDate}>
+                  {bonsai.bonsaiChapters[
+                    currentChapterIndex
+                  ].date.toDateString()}
+                </p>
+                <p className={styles.chapterCaption}>
+                  {bonsai.bonsaiChapters[currentChapterIndex].caption}
+                </p>
+              </div>
+
+              <div className={styles.imageGallery}>
+                <button onClick={handlePrevPhoto} disabled={isProcessing}>
+                  {'<'}
+                </button>
+                <div className={styles.imageFrame}>
+                  <img
+                    src={
+                      bonsai.bonsaiChapters[currentChapterIndex].photoUrls[0]
+                    }
+                    alt={`Bonsai Chapter ${currentChapterIndex + 1} Photo`}
+                    className={styles.chapterImage}
+                    onLoad={() => setIsProcessing(false)}
+                  />
+                </div>
+                <button onClick={handleNextPhoto} disabled={isProcessing}>
+                  {'>'}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/bonsaiSubmitForm/BonsaiSubmitForm.tsx
+++ b/src/components/bonsaiSubmitForm/BonsaiSubmitForm.tsx
@@ -1,31 +1,6 @@
 import React from 'react';
 import styles from '../bonsaiSubmitForm/BonsaSubmitForm.module.css';
-
-interface BonsaiData {
-  hardiness_zone: string;
-  height: number | '';
-  width: number | '';
-  nebari: number | '';
-  style: string;
-  species: string;
-}
-
-interface BonsaiChapter {
-  photos: (File | null)[];
-  caption: string;
-  date: Date;
-}
-
-interface BonsaiSubmitFormProps {
-  bonsaiData: BonsaiData;
-  bonsaiChapterArr: BonsaiChapter[];
-  onAddNewChapter: () => void;
-  onEditData: () => void;
-  onEditChapter: (index: number) => void;
-  onDiscardBonsai: () => void;
-  onSubmitBonsai: () => void;
-  onDeleteChapter: (index: number) => void;
-}
+import { BonsaiSubmitFormProps} from '../../interfaces';
 
 const BonsaiSubmitForm: React.FC<BonsaiSubmitFormProps> = ({
   bonsaiData,
@@ -41,7 +16,7 @@ const BonsaiSubmitForm: React.FC<BonsaiSubmitFormProps> = ({
     <div className={styles.container}>
       <h2>Bonsai Data</h2>
       <div>
-        <strong>Hardiness Zone:</strong> {bonsaiData.hardiness_zone}
+        <strong>Hardiness Zone:</strong> {bonsaiData.hardinessZone}
       </div>
       <div>
         <strong>Height:</strong> {bonsaiData.height}

--- a/src/components/bonsaiUpload/BonsaiUpload.tsx
+++ b/src/components/bonsaiUpload/BonsaiUpload.tsx
@@ -3,25 +3,11 @@ import BonsaiDataForm from '../bonsaiDataForm/BonsaiDataForm';
 import BonsaiChapterForm from '../bonsaiChapterForm/BonsaiChapterForm';
 import BonsaiSubmitForm from '../bonsaiSubmitForm/BonsaiSubmitForm';
 import styles from './BonsaiUpload.module.css';
-
-interface BonsaiData {
-  hardiness_zone: string;
-  height: number | '';
-  width: number | '';
-  nebari: number | '';
-  style: string;
-  species: string;
-}
-
-interface BonsaiChapter {
-  photos: (File | null)[];
-  caption: string;
-  date: Date;
-}
+import { Bonsai, BonsaiChapterFile } from '../../interfaces';
 
 function BonsaiUpload() {
-  const [bonsaiData, setBonsaiData] = useState<BonsaiData | null>(null);
-  const [bonsaiChapterArr, setBonsaiChapterArr] = useState<BonsaiChapter[]>([]);
+  const [bonsaiData, setBonsaiData] = useState<Bonsai | null>(null);
+  const [bonsaiChapterArr, setBonsaiChapterArr] = useState<BonsaiChapterFile[]>([]);
   const [currentForm, setCurrentForm] = useState<'data' | 'chapter' | 'submit'>(
     'data'
   );
@@ -29,13 +15,13 @@ function BonsaiUpload() {
     null
   );
 
-  const handleDataSubmit = (data: BonsaiData) => {
+  const handleDataSubmit = (data: Bonsai) => {
     setBonsaiData(data);
     setCurrentForm('chapter');
     console.log('bonsai data: ', bonsaiData);
   };
 
-  const handleChapterSubmit = (chapter: BonsaiChapter) => {
+  const handleChapterSubmit = (chapter: BonsaiChapterFile) => {
     if (bonsaiChapterIndex !== null) {
       const newChapterArr = [...bonsaiChapterArr];
       newChapterArr[bonsaiChapterIndex] = chapter;

--- a/src/components/bonsaiUpload/BonsaiUpload.tsx
+++ b/src/components/bonsaiUpload/BonsaiUpload.tsx
@@ -4,6 +4,7 @@ import BonsaiChapterForm from '../bonsaiChapterForm/BonsaiChapterForm';
 import BonsaiSubmitForm from '../bonsaiSubmitForm/BonsaiSubmitForm';
 import styles from './BonsaiUpload.module.css';
 import { Bonsai, BonsaiChapterFile } from '../../interfaces';
+import {userData} from '../../bonsaiProfDummyData';
 
 function BonsaiUpload() {
   const [bonsaiData, setBonsaiData] = useState<Bonsai | null>(null);
@@ -65,9 +66,9 @@ function BonsaiUpload() {
     <div className={styles.container}>
       {currentForm === 'data' &&
         (bonsaiData !== null ? (
-          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} />
+          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} userData={bonsaiData.user}/>
         ) : (
-          <BonsaiDataForm onSubmit={handleDataSubmit} />
+          <BonsaiDataForm onSubmit={handleDataSubmit} userData={userData}/>
         ))}
       {currentForm === 'chapter' &&
         (bonsaiChapterIndex !== null ? (

--- a/src/components/errorBoundary/ErrorBoundary.tsx
+++ b/src/components/errorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React, { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/home/Home.module.css
+++ b/src/components/home/Home.module.css
@@ -1,0 +1,4 @@
+.cardDivider {
+  max-width: 900px;
+  width: 100%;
+}

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,15 +1,16 @@
-import { bonsaiCardData } from '../../bonsaiProfDummyData';
+import { bonsaiData } from '../../bonsaiProfDummyData';
 import styles from './Home.module.css';
 import BonsaiCard from '../bonsaiCard/BonsaiCard';
 
 export default function Home() {
   return (
     <>
-      <BonsaiCard cardData={bonsaiCardData} />
+      <BonsaiCard bonsai={bonsaiData} />
       <hr className={styles.cardDivider} />
-      <BonsaiCard cardData={bonsaiCardData} />
+      <BonsaiCard bonsai={bonsaiData} />
       <hr className={styles.cardDivider} />
-      <BonsaiCard cardData={bonsaiCardData} />
+      <BonsaiCard bonsai={bonsaiData} />
+      <hr className={styles.cardDivider} />
     </>
   );
 }

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,11 +1,14 @@
 import { bonsaiCardData } from '../../bonsaiProfDummyData';
+import styles from './Home.module.css';
 import BonsaiCard from '../bonsaiCard/BonsaiCard';
 
 export default function Home() {
   return (
     <>
       <BonsaiCard cardData={bonsaiCardData} />
+      <hr className={styles.cardDivider} />
       <BonsaiCard cardData={bonsaiCardData} />
+      <hr className={styles.cardDivider} />
       <BonsaiCard cardData={bonsaiCardData} />
     </>
   );

--- a/src/components/menu/Menu.module.css
+++ b/src/components/menu/Menu.module.css
@@ -53,7 +53,7 @@
 
 .exitButton:hover {
   cursor: pointer;
-  background-color: var(--primary-color-site);
+  background-color: var(--secondary-color-site);
 }
 
 .divider {
@@ -70,5 +70,5 @@
 
 .menuItem:hover {
   cursor: pointer;
-  background-color: var(--primary-color-site);
+  background-color: var(--secondary-color-site);
 }

--- a/src/components/menu/Menu.module.css
+++ b/src/components/menu/Menu.module.css
@@ -56,7 +56,7 @@
   background-color: var(--primary-color-site);
 }
 
-hr {
+.divider {
   background-color: black;
   height: 1px;
   width: 100%;

--- a/src/components/menu/Menu.module.css
+++ b/src/components/menu/Menu.module.css
@@ -22,7 +22,7 @@
   object-fit: cover;
   background-color: transparent;
   border-radius: 50%;
-  border: 2px solid black;
+  border: 2px solid var(--primary-color-site);
 }
 
 .userInfo {
@@ -43,8 +43,8 @@
 }
 
 .exitButton {
-  height: 35px;
-  width: 35px;
+  height: 30px;
+  width: 30px;
   background-color: transparent;
   border: none;
   border-radius: 5px;
@@ -53,11 +53,11 @@
 
 .exitButton:hover {
   cursor: pointer;
-  background-color: var(--secondary-color-site);
+  background-color: rgb(255, 66, 66);
 }
 
 .divider {
-  background-color: black;
+  background-color: var(--primary-color-site);
   height: 1px;
   width: 100%;
   border: none;
@@ -66,9 +66,10 @@
 .menuItem {
   text-decoration: underline;
   width: 100%;
+  padding: 3px;
 }
 
 .menuItem:hover {
   cursor: pointer;
-  background-color: var(--secondary-color-site);
+  background-color: var(--primary-color-site);
 }

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,18 +1,11 @@
 import styles from './Menu.module.css';
 import { useNavigate } from 'react-router-dom';
+import {User} from '../../interfaces';
 
-interface User {
-  avatar: string;
-  username: string;
-  fullname: string;
-}
-
-interface MenuProps {
+export default function Menu({ user, menuToggle }: {
   user: User;
   menuToggle: () => void;
-}
-
-export default function Menu({ user, menuToggle }: MenuProps) {
+}) {
   const navigate = useNavigate();
 
   const handleLinkClick = (path: string) => {

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -32,7 +32,7 @@ export default function Menu({ user, menuToggle }: MenuProps) {
           X
         </button>
       </div>
-      <hr />
+      <hr className={styles.divider} />
       <div
         onClick={() => handleLinkClick('/upload')}
         className={styles.menuItem}

--- a/src/components/navBar/NavBar.module.css
+++ b/src/components/navBar/NavBar.module.css
@@ -108,7 +108,7 @@
 
 .menu {
   z-index: 5;
-  background-color: var(--primary-color-site);
+  background-color: whitesmoke;
   height: 100vh;
   width: 300px;
   position: fixed;
@@ -116,6 +116,7 @@
   right: 0;
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
+  border-left: 1px solid var(--primary-color-site);
 }
 
 .divider {

--- a/src/components/navBar/NavBar.module.css
+++ b/src/components/navBar/NavBar.module.css
@@ -41,7 +41,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background-color: rgba(128, 128, 128, 0.2);
+  background-color: var(--subtle-background);
   border-radius: 24px;
   padding: 4px 12px;
   height: min-content;

--- a/src/components/navBar/NavBar.module.css
+++ b/src/components/navBar/NavBar.module.css
@@ -108,7 +108,7 @@
 
 .menu {
   z-index: 5;
-  background-color: var(--secondary-color-site);
+  background-color: var(--primary-color-site);
   height: 100vh;
   width: 300px;
   position: fixed;

--- a/src/components/navBar/NavBar.module.css
+++ b/src/components/navBar/NavBar.module.css
@@ -118,8 +118,9 @@
   border-bottom-left-radius: 10px;
 }
 
-hr {
+.divider {
   margin: 10px 0;
+  width: 100%;
   border: 0;
   border-top: 1px solid var(--primary-color-site);
 }

--- a/src/components/navBar/NavBar.tsx
+++ b/src/components/navBar/NavBar.tsx
@@ -79,7 +79,7 @@ function NavBar() {
           </div>
         )}
       </div>
-      <hr />
+      <hr className={styles.divider} />
     </>
   );
 }

--- a/src/components/userIcon/UserIcon.tsx
+++ b/src/components/userIcon/UserIcon.tsx
@@ -1,8 +1,5 @@
 import styles from './UserIcon.module.css';
-
-interface User {
-  username: string;
-}
+import { User } from '../../interfaces';
 
 function UserIcon({ user }: { user: User }) {
   return (
@@ -10,7 +7,7 @@ function UserIcon({ user }: { user: User }) {
       <button className={styles.userIconContainer}>
         <img
           src={
-            'https://res.cloudinary.com/dscsiijis/image/upload/v1721414755/IMG_3701_bkure4.jpg'
+            user.avatar 
           }
           className={styles.userIcon}
           alt="user avatar"

--- a/src/index.css
+++ b/src/index.css
@@ -2,4 +2,5 @@
   --primary-color-site: seagreen;
   --secondary-color-site: rgb(38, 137, 176);
   --font-family: 'Arial, sans-serif';
+  --subtle-background: rgba(128, 128, 128, 0.2);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  --primary-color-site: seagreen;
+  --primary-color-site: rgba(32, 137, 32, 0.8);
   --secondary-color-site: rgb(38, 137, 176);
   --font-family: 'Arial, sans-serif';
-  --subtle-background: rgba(128, 128, 128, 0.2);
+  --subtle-background: rgb(230, 230, 230);
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,9 +5,16 @@ export interface BonsaiChapter {
   bonsaiId: string;
 }
 
+export interface User {
+  avatar: string;
+  username: string;
+  fullname: string;
+}
+
+
 export interface Bonsai {
   id: string;
-  user: string;
+  user: User;
   species: string;
   geoLocation: string;
   style: string;
@@ -18,11 +25,6 @@ export interface Bonsai {
   bonsaiChapters: BonsaiChapter[];
 }
 
-export interface User {
-  avatar: string;
-  username: string;
-  fullname: string;
-}
 
 
 // upload

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,19 @@
+export interface BonsaiChapter {
+  photoUrls: string[];
+  date: Date;
+  caption: string;
+  bonsaiId: string;
+}
+
+export interface Bonsai {
+  id: string;
+  user: string;
+  species: string;
+  geoLocation: string;
+  style: string;
+  height: string;
+  width: string;
+  nebari: string;
+  hardinessZone: string;
+  bonsaiChapters: BonsaiChapter[];
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,3 +25,14 @@ export interface BonsaiChapterFile {
   caption: string;
   date: Date;
 }
+
+export interface BonsaiSubmitFormProps {
+  bonsaiData: Bonsai;
+  bonsaiChapterArr: BonsaiChapterFile[];
+  onAddNewChapter: () => void;
+  onEditData: () => void;
+  onEditChapter: (index: number) => void;
+  onDiscardBonsai: () => void;
+  onSubmitBonsai: () => void;
+  onDeleteChapter: (index: number) => void;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,3 +17,11 @@ export interface Bonsai {
   hardinessZone: string;
   bonsaiChapters: BonsaiChapter[];
 }
+
+// upload
+
+export interface BonsaiChapterFile {
+  photos: (File | null)[];
+  caption: string;
+  date: Date;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,13 @@ export interface Bonsai {
   bonsaiChapters: BonsaiChapter[];
 }
 
+export interface User {
+  avatar: string;
+  username: string;
+  fullname: string;
+}
+
+
 // upload
 
 export interface BonsaiChapterFile {


### PR DESCRIPTION
Extracts interfaces to a file. References a single bonsai interface instead of partial data sets for distinct uses (e.g BonsaiCardData). Refactor bonsai card view to present first image in each chapter (as user navigates). Add error boundary. Try to make everything a bit less ugly on the way.