### PR TITLE
Optional bonsai fields

### DIFF
--- a/src/BonsaiCategoryConstants.tsx
+++ b/src/BonsaiCategoryConstants.tsx
@@ -1,8 +1,51 @@
-export const HARDINESSZONES = ['0a', '0b', '1a', '1b', '2a', '2b', '3a', '3b', 
-'4a', '4b', '5a', '5b', '6a', '6b', '7a', '7b', '8a', '8b', '9a', '9b',
-'10a', '10b', '11a', '11b', '12a', '12b', '13a', '13b'];
+export const HARDINESSZONES = [
+  '0a',
+  '0b',
+  '1a',
+  '1b',
+  '2a',
+  '2b',
+  '3a',
+  '3b',
+  '4a',
+  '4b',
+  '5a',
+  '5b',
+  '6a',
+  '6b',
+  '7a',
+  '7b',
+  '8a',
+  '8b',
+  '9a',
+  '9b',
+  '10a',
+  '10b',
+  '11a',
+  '11b',
+  '12a',
+  '12b',
+  '13a',
+  '13b'
+];
 
-export const BONSAISTYLES = ['Broom style (Hokidachi)', 'Cascade (Kengai)', 'Double trunk (Sokan)',
-'Formal upright (Chokkan)', 'Forest (Yose-ue)', 'Growing in a rock (Ishisuki)', 'Growing on a rock (Seki-Joju)',
-'Informal upright (Moyogi)', 'Literati (Bunjin-gi)', 'Multi-trunk (Ikadabuki)',  'Raft (Ikadabuki)',
-'Semi-cascade (Han-kengai)', 'Shari (Sharimiki)', 'Slanting (Shakan)', 'Windswept (Fukinagashi)', 'Other'];
+export const BONSAISTYLES = [
+  'Broom style (Hokidachi)',
+  'Cascade (Kengai)',
+  'Double trunk (Sokan)',
+  'Formal upright (Chokkan)',
+  'Forest (Yose-ue)',
+  'Growing in a rock (Ishisuki)',
+  'Growing on a rock (Seki-Joju)',
+  'Informal upright (Moyogi)',
+  'Literati (Bunjin-gi)',
+  'Multi-trunk (Ikadabuki)',
+  'Raft (Ikadabuki)',
+  'Semi-cascade (Han-kengai)',
+  'Shari (Sharimiki)',
+  'Slanting (Shakan)',
+  'Windswept (Fukinagashi)',
+  'Other'
+];
+
+export const OPTIONALBONSAIFIELDS = ['style', 'height', 'width', 'nebari'];

--- a/src/BonsaiCategoryConstants.tsx
+++ b/src/BonsaiCategoryConstants.tsx
@@ -29,7 +29,7 @@ export const HARDINESSZONES = [
   '13b'
 ];
 
-export const BONSAISTYLES = [
+export const STYLES = [
   'Broom style (Hokidachi)',
   'Cascade (Kengai)',
   'Double trunk (Sokan)',
@@ -48,4 +48,4 @@ export const BONSAISTYLES = [
   'Other'
 ];
 
-export const OPTIONALBONSAIFIELDS = ['style', 'height', 'width', 'nebari'];
+export const OPTIONALFIELDS = ['style', 'height', 'width', 'nebari'];

--- a/src/BonsaiCategoryConstants.tsx
+++ b/src/BonsaiCategoryConstants.tsx
@@ -48,4 +48,3 @@ export const STYLES = [
   'Other'
 ];
 
-export const OPTIONALFIELDS = ['style', 'height', 'width', 'nebari'];

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -69,7 +69,6 @@ function BonsaiDataForm({
           type="number"
           value={height}
           onChange={(e) => setHeight(e.target.value)}
-          required
         />
       </div>
       <div>
@@ -93,7 +92,6 @@ function BonsaiDataForm({
         <select
           value={style}
           onChange={(e) => setStyle(e.target.value)}
-          required
           id="style"
         >
           <option value="" disabled>

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -30,13 +30,13 @@ function BonsaiDataForm({
       geoLocation: geoLocation,
       bonsaiChapters: [],
       hardinessZone: hardinessZone,
-      height: height,
       species: species,
-      width: width !== '' ? width : '',
-      nebari: nebari !== '' ? nebari : '',
-      style: style !== '' ? style : ''
     };
-   
+    // Add in optional fields if they are not empty
+    if (width !== '') bonsaiData.width = width;
+    if (nebari !== '') bonsaiData.nebari = nebari;
+    if (style !== '') bonsaiData.style = style;
+    if (height !== '') bonsaiData.height = height;
     onSubmit(bonsaiData);
   };
 

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styles from './BonsaiDataForm.module.css';
 import { Bonsai, User } from '../../interfaces';
-import { HARDINESSZONES, STYLES, OPTIONALFIELDS } from '../../BonsaiCategoryConstants';
+import { HARDINESSZONES, STYLES} from '../../BonsaiCategoryConstants';
 
 function BonsaiDataForm({
   onSubmit,
@@ -36,6 +36,7 @@ function BonsaiDataForm({
       nebari: nebari !== '' ? nebari : '',
       style: style !== '' ? style : ''
     };
+   
     onSubmit(bonsaiData);
   };
 

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -10,7 +10,7 @@ function BonsaiDataForm({
 }: {
   onSubmit: (data: Bonsai) => void;
   bonsaiData?: Bonsai;
-  userData: User;
+  userData: UserPartial;
 }) {
   const [hardinessZone, setHardinessZone] = useState(
     bonsaiData?.hardinessZone || ''

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styles from './BonsaiDataForm.module.css';
 import { Bonsai, User } from '../../interfaces';
-import { HARDINESSZONES, BONSAISTYLES } from '../../BonsaiCategoryConstants';
+import { HARDINESSZONES, STYLES, OPTIONALFIELDS } from '../../BonsaiCategoryConstants';
 
 function BonsaiDataForm({
   onSubmit,
@@ -43,12 +43,14 @@ function BonsaiDataForm({
     <form onSubmit={handleSubmit}>
       <h2>Add Bonsai Data</h2>
       <div>
-        <label className={styles.hardinessLabel} htmlFor='hardiness'>Hardiness Zone:</label>
+        <label className={styles.hardinessLabel} htmlFor="hardiness">
+          Hardiness Zone:
+        </label>
         <select
           value={hardinessZone}
           onChange={(e) => setHardinessZone(e.target.value)}
           required
-          id='hardiness'
+          id="hardiness"
         >
           <option value="" disabled>
             Select Hardiness Zone
@@ -65,9 +67,7 @@ function BonsaiDataForm({
         <input
           type="number"
           value={height}
-          onChange={(e) =>
-            setHeight(e.target.value )
-          }
+          onChange={(e) => setHeight(e.target.value)}
           required
         />
       </div>
@@ -76,9 +76,7 @@ function BonsaiDataForm({
         <input
           type="number"
           value={width}
-          onChange={(e) =>
-            setWidth(e.target.value )
-          }
+          onChange={(e) => setWidth(e.target.value)}
         />
       </div>
       <div>
@@ -86,23 +84,21 @@ function BonsaiDataForm({
         <input
           type="number"
           value={nebari}
-          onChange={(e) =>
-            setNebari(e.target.value )
-          }
+          onChange={(e) => setNebari(e.target.value)}
         />
       </div>
       <div>
-      <label htmlFor="style">Bonsai Style: </label>
-      <select
+        <label htmlFor="style">Bonsai Style: </label>
+        <select
           value={style}
           onChange={(e) => setStyle(e.target.value)}
           required
-          id='style'
+          id="style"
         >
           <option value="" disabled>
             Select Style
           </option>
-          {BONSAISTYLES.map((style) => (
+          {STYLES.map((style) => (
             <option key={style} value={style}>
               {style}
             </option>

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -26,7 +26,7 @@ function BonsaiDataForm({
     event.preventDefault();
     const bonsaiData: Bonsai = {
       id: '',
-      user: userData,
+      username: userData.username,
       geoLocation: geoLocation,
       bonsaiChapters: [],
       hardinessZone: hardinessZone,

--- a/src/components/bonsaiDataForm/BonsaiDataForm.tsx
+++ b/src/components/bonsaiDataForm/BonsaiDataForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styles from './BonsaiDataForm.module.css';
-import { Bonsai, User } from '../../interfaces';
+import { Bonsai, UserPartial } from '../../interfaces';
 import { HARDINESSZONES, STYLES} from '../../BonsaiCategoryConstants';
 
 function BonsaiDataForm({

--- a/src/components/bonsaiSubmitForm/BonsaiSubmitForm.tsx
+++ b/src/components/bonsaiSubmitForm/BonsaiSubmitForm.tsx
@@ -37,16 +37,16 @@ const BonsaiSubmitForm: React.FC<BonsaiSubmitFormProps> = ({
         <strong>Hardiness Zone:</strong> {bonsaiData.hardinessZone}
       </div>
       <div>
-        <strong>Height:</strong> {bonsaiData.height}
+        <strong>Height:</strong> {bonsaiData.height || 'N/A'}
       </div>
       <div>
-        <strong>Width:</strong> {bonsaiData.width}
+        <strong>Width:</strong> {bonsaiData.width || 'N/A'}
       </div>
       <div>
-        <strong>Nebari:</strong> {bonsaiData.nebari}
+        <strong>Nebari:</strong> {bonsaiData.nebari || 'N/A'}
       </div>
       <div>
-        <strong>Style:</strong> {bonsaiData.style}
+        <strong>Style:</strong> {bonsaiData.style || 'N/A'}
       </div>
       <div>
         <strong>Species:</strong> {bonsaiData.species}

--- a/src/components/bonsaiUpload/BonsaiUpload.tsx
+++ b/src/components/bonsaiUpload/BonsaiUpload.tsx
@@ -5,6 +5,7 @@ import BonsaiSubmitForm from '../bonsaiSubmitForm/BonsaiSubmitForm';
 import styles from './BonsaiUpload.module.css';
 import { Bonsai, BonsaiChapterFile } from '../../interfaces';
 import AuthContext from '../../AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 
 function BonsaiUpload() {
@@ -17,6 +18,14 @@ function BonsaiUpload() {
     null
   );
   const { username } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  // must be logged in to upload a bonsai
+  useEffect(() => {
+    if (!username) {
+      navigate('/')
+    }
+  },[username]);
 
   const handleDataSubmit = (data: Bonsai) => {
     setBonsaiData(data);

--- a/src/components/bonsaiUpload/BonsaiUpload.tsx
+++ b/src/components/bonsaiUpload/BonsaiUpload.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import BonsaiDataForm from '../bonsaiDataForm/BonsaiDataForm';
 import BonsaiChapterForm from '../bonsaiChapterForm/BonsaiChapterForm';
 import BonsaiSubmitForm from '../bonsaiSubmitForm/BonsaiSubmitForm';
 import styles from './BonsaiUpload.module.css';
 import { Bonsai, BonsaiChapterFile } from '../../interfaces';
-import { userData } from '../../bonsaiProfDummyData';
+import AuthContext from '../../AuthContext';
+
 
 function BonsaiUpload() {
   const [bonsaiData, setBonsaiData] = useState<Bonsai | null>(null);
@@ -15,6 +16,7 @@ function BonsaiUpload() {
   const [bonsaiChapterIndex, setBonsaiChapterIndex] = useState<null | number>(
     null
   );
+  const { username } = useContext(AuthContext);
 
   const handleDataSubmit = (data: Bonsai) => {
     setBonsaiData(data);
@@ -67,9 +69,9 @@ function BonsaiUpload() {
     <div className={styles.container}>
       {currentForm === 'data' &&
         (bonsaiData !== null ? (
-          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} userData={bonsaiData.user} />
+          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} userData={{username: username }} />
         ) : (
-          <BonsaiDataForm onSubmit={handleDataSubmit} userData={userData} />
+          <BonsaiDataForm onSubmit={handleDataSubmit} userData={{username: username}} />
         ))}
       {currentForm === 'chapter' &&
         (bonsaiChapterIndex !== null ? (

--- a/src/components/bonsaiUpload/BonsaiUpload.tsx
+++ b/src/components/bonsaiUpload/BonsaiUpload.tsx
@@ -78,9 +78,9 @@ function BonsaiUpload() {
     <div className={styles.container}>
       {currentForm === 'data' &&
         (bonsaiData !== null ? (
-          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} userData={{username: username }} />
+          <BonsaiDataForm onSubmit={handleDataSubmit} bonsaiData={bonsaiData} userData={{username: username ?? '' }} />
         ) : (
-          <BonsaiDataForm onSubmit={handleDataSubmit} userData={{username: username}} />
+          <BonsaiDataForm onSubmit={handleDataSubmit}  userData={{username: username ?? '' }}  />
         ))}
       {currentForm === 'chapter' &&
         (bonsaiChapterIndex !== null ? (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface UserIcon {
 
 export interface Bonsai {
   id: string;
-  user: User;
+  user: UserPartial;
   species: string;
   geoLocation: string;
   style?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,12 @@ export interface BonsaiChapter {
   bonsaiId: string;
 }
 
-export interface User {
+export interface UserPartial {
+  username: string;
+  profilePhoto?: string;
+}
+
+export interface UserFull {
   id: string;
   profilePhoto: string;
   username: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,10 +23,10 @@ export interface Bonsai {
   user: User;
   species: string;
   geoLocation: string;
-  style: string;
-  height: string;
-  width: string;
-  nebari: string;
+  style?: string;
+  height?: string;
+  width?: string;
+  nebari?: string;
   hardinessZone: string;
   bonsaiChapters: BonsaiChapter[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface UserIcon {
 
 export interface Bonsai {
   id: string;
-  user: UserPartial;
+  username: string;
   species: string;
   geoLocation: string;
   style?: string;


### PR DESCRIPTION
Make measurement (height, width, nebari) and style fields optional.
Make minor updates to upload form. Namely: redirect the user if they are not authenticated, and use the actual username from the authContext in the upload process, instead of dummy data. To facilitate this, the User interface was updated (factored out, more like) into PartialUser and FullUser. Partial user works with the data that the backend provides on authentication (username, profile photo). This serves most needs. All, in fact—until we implement user pages and user settings pages which require full user objects.